### PR TITLE
Removed the need to have a typers.json

### DIFF
--- a/lib/commands/install.js
+++ b/lib/commands/install.js
@@ -13,10 +13,9 @@ function install (options, font) {
       .display
         (
           'Typers couldn\'t find "typers.json" in this folder.\n'.red +
-          'Hint: You would to use `typers init` to create it.'.gray
+          'Hint: You would to use `typers init` to create it.\n'.gray +
+          'Info: Your font will be downloaded even without "typers.json"'.green
         );
-
-    process.exit(-1);
   };
 
   if (font) {
@@ -57,8 +56,14 @@ function remoteInstall (font) {
 
   search.on('data', function (buffer) {
     InitConfigEngine.read(function (error, data) {
-    var config = JSON.parse(data);
-
+    var config = {};
+      
+    if (data) {
+      config = JSON.parse(data);
+    } else {
+      config.directory = '/';
+    }
+    
     if (this.options.minify) {
       buffer = new CleanCSS().minify(buffer);
     };


### PR DESCRIPTION
- From now on, developers can download fonts without having a typers.json
- Fonts will be downloaded to the root directory where the "typers install" command was executed.
